### PR TITLE
fix compatibility with actual golang-evdev

### DIFF
--- a/shift-shift.go
+++ b/shift-shift.go
@@ -16,7 +16,7 @@ import "C"
 import (
 	"flag"
 	"fmt"
-	evdev "github.com/gvalkov/golang-evdev"
+    "github.com/gvalkov/golang-evdev/evdev"
 	"os"
 	// "os/exec"
 	"os/signal"
@@ -86,7 +86,7 @@ func scanDevices(mbox chan Message) {
 		case input := <-kbdLost:
 			delete(keyboards, input)
 		default:
-			devnames, err := evdev.ListInputDevices("/dev/input/event*")
+			devnames, err := evdev.ListInputDevicePaths("/dev/input/event*")
 			if err == nil && len(devnames) > 0 {
 				for _, input := range devnames {
 					dev, err := evdev.Open(input)


### PR DESCRIPTION
Hello.

After the golang-evdev package has been moved to sub-directory (`evdev`), there were some errors like `no buildable go source`.
And when I'm trying manually compile shift-shift, I got some errors:

```
./shift-shift.go:92: cannot use input (type *evdev.InputDevice) as type string in argument to evdev.Open
./shift-shift.go:98: cannot use input (type *evdev.InputDevice) as type string in map index
./shift-shift.go:101: cannot use input (type *evdev.InputDevice) as type string in map index
./shift-shift.go:102: cannot use input (type *evdev.InputDevice) as type string in argument to listenEvents
```

I'm fixed that.
