### PR TITLE
temporarily use fixed fork of golang-evdev

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Install
 
 Binding of `evdev` for Go used so before build you need:
 
-    go get github.com/gvalkov/golang-evdev/evdev
+    go get github.com/kovetskiy/golang-evdev/evdev
 
 Then as usual:
 

--- a/shift-shift.go
+++ b/shift-shift.go
@@ -22,7 +22,7 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/gvalkov/golang-evdev"
+	"github.com/kovetskiy/golang-evdev"
 )
 
 // Объединение данных для удобства передачи по каналу.


### PR DESCRIPTION
Hi, current golang-evdev implementation contains a problem with IOC_READ and
EV_REP capability, so users of shift-shift constantly get `unable to open
device /path/to/device: invalid argument` and the program doesn't work as expected.

I've fixed the error in evdev bindings and sent to upstream, but it could take
some time for merging.

Patch:
https://github.com/gvalkov/golang-evdev/pull/18