### PR TITLE
Revert "temporarily use fixed fork of golang-evdev"

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Install
 
 Binding of `evdev` for Go used so before build you need:
 
-    go get github.com/kovetskiy/golang-evdev/evdev
+    go get github.com/gvalkov/golang-evdev/evdev
 
 Then as usual:
 

--- a/shift-shift.go
+++ b/shift-shift.go
@@ -22,7 +22,7 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/kovetskiy/golang-evdev"
+	"github.com/gvalkov/golang-evdev"
 )
 
 // Объединение данных для удобства передачи по каналу.


### PR DESCRIPTION
This reverts commit 8cfee65609d640b69858b59744890d960f5b9d48.

The PR has been merged so shift-shift can switch to upstream golang-evdev now again.
https://github.com/gvalkov/golang-evdev/pull/18#event-2798914172